### PR TITLE
Prevent duplicate and adjacent commands from queuing in history.

### DIFF
--- a/cypress/e2e/History.cy.ts
+++ b/cypress/e2e/History.cy.ts
@@ -6,6 +6,8 @@ beforeEach(() => {
     cy.sverminalType('{enter}');
     cy.sverminalType('test');
     cy.sverminalType('{enter}');
+    cy.sverminalType('test');
+    cy.sverminalType('{enter}');
 })
 
 describe('sverminal history - USER ACTIONS UP AND DOWN ARROWS', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sverminal",
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"description": "Terminal emulator component built with Svelte and Tailwind.",
 	"license": "MIT",
     "repository": {

--- a/src/lib/Sverminal.svelte
+++ b/src/lib/Sverminal.svelte
@@ -82,8 +82,11 @@
 			}
 			appendNewCommandLine();
 
-			//Regardless of the result, save the command in history.
-			commandHistory.push(command);
+			//Regardless of the result, save the command in history if it is a new command.
+            const lastCommand = commandHistory.get(0);
+            if(command != lastCommand){
+                commandHistory.push(command);
+            }
             commandInProgress = false;
 		}
 	}


### PR DESCRIPTION
Prevent duplicate and adjacent commands from queuing in history.